### PR TITLE
Align repo with proposed folder layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ The solution file `TimeTracker.sln` includes the API, agent and backoffice proje
 3. The client project can be started with `npm start` once dependencies are installed in `src/TimeTracker.Client`.
 
 This layout is intended as a starting point and will evolve as features are implemented.
+
+### Project Structure
+
+```
+time-tracker-mcp/
+├── src/
+│   ├── TimeTracker.Api/
+│   │   └── Controllers/
+│   ├── TimeTracker.Agent/
+│   │   └── Services/
+│   ├── TimeTracker.Backoffice/
+│   │   └── Pages/
+│   └── TimeTracker.Client/
+└── tests/
+```
+
+Each project has its own directory with source files grouped under these folders.

--- a/src/TimeTracker.Agent/Program.cs
+++ b/src/TimeTracker.Agent/Program.cs
@@ -1,4 +1,13 @@
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<TimeTracker.Agent.Services.IAgentService,
+    TimeTracker.Agent.Services.AgentService>();
+
 var app = builder.Build();
-app.MapPost("/records", () => "Record endpoint");
+
+app.MapPost("/records", (string input, TimeTracker.Agent.Services.IAgentService service) =>
+{
+    return service.Process(input);
+});
+
 app.Run();

--- a/src/TimeTracker.Agent/Services/AgentService.cs
+++ b/src/TimeTracker.Agent/Services/AgentService.cs
@@ -1,0 +1,11 @@
+namespace TimeTracker.Agent.Services;
+
+public interface IAgentService
+{
+    string Process(string input);
+}
+
+public class AgentService : IAgentService
+{
+    public string Process(string input) => $"Processed {input}";
+}

--- a/src/TimeTracker.Api/Controllers/ChatController.cs
+++ b/src/TimeTracker.Api/Controllers/ChatController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TimeTracker.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ChatController : ControllerBase
+{
+    [HttpGet("ping")]
+    public IActionResult Ping() => Ok("pong");
+}

--- a/src/TimeTracker.Api/Program.cs
+++ b/src/TimeTracker.Api/Program.cs
@@ -1,4 +1,9 @@
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
 var app = builder.Build();
-app.MapGet("/", () => "TimeTracker.Api running");
+
+app.MapControllers();
+
 app.Run();

--- a/src/TimeTracker.Backoffice/Pages/Index.cshtml
+++ b/src/TimeTracker.Backoffice/Pages/Index.cshtml
@@ -1,0 +1,3 @@
+@page
+<h1>Backoffice</h1>
+<p>Management dashboard placeholder.</p>

--- a/src/TimeTracker.Backoffice/Program.cs
+++ b/src/TimeTracker.Backoffice/Program.cs
@@ -1,4 +1,9 @@
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
 var app = builder.Build();
-app.MapGet("/admin", () => "Backoffice running");
+
+app.MapRazorPages();
+
 app.Run();


### PR DESCRIPTION
## Summary
- add Controller, Services, and Pages folders to match earlier design
- implement basic `ChatController` and `AgentService`
- hook up Razor Pages for Backoffice
- document the project layout in `README.md`

## Testing
- `dotnet build TimeTracker.sln` *(fails: `dotnet` not found)*
- `npm --prefix src/TimeTracker.Client test`

------
https://chatgpt.com/codex/tasks/task_e_685554beef34832b847bae306fc719ac