### PR TITLE
Add chat endpoints to API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,5 +3,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.301"
+    "version": "9.0.100",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/TimeTracker.Api/Controllers/ChatController.cs
+++ b/src/TimeTracker.Api/Controllers/ChatController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using TimeTracker.Api.Models;
+using TimeTracker.Api.Services;
 
 namespace TimeTracker.Api.Controllers;
 
@@ -6,6 +8,24 @@ namespace TimeTracker.Api.Controllers;
 [Route("[controller]")]
 public class ChatController : ControllerBase
 {
+    private readonly IChatService _chatService;
+
+    public ChatController(IChatService chatService)
+    {
+        _chatService = chatService;
+    }
+
     [HttpGet("ping")]
     public IActionResult Ping() => Ok("pong");
+
+    [HttpGet("messages")]
+    public ActionResult<IEnumerable<ChatMessage>> GetMessages()
+        => Ok(_chatService.GetHistory());
+
+    [HttpPost("message")]
+    public ActionResult<ChatResponse> PostMessage(ChatRequest request)
+    {
+        var response = _chatService.Send(request.Text);
+        return Ok(new ChatResponse(response.Text));
+    }
 }

--- a/src/TimeTracker.Api/Controllers/ChatController.cs
+++ b/src/TimeTracker.Api/Controllers/ChatController.cs
@@ -5,7 +5,7 @@ using TimeTracker.Api.Services;
 namespace TimeTracker.Api.Controllers;
 
 [ApiController]
-[Route("[controller]")]
+[Route("api/[controller]")]
 public class ChatController : ControllerBase
 {
     private readonly IChatService _chatService;

--- a/src/TimeTracker.Api/Models/ChatMessage.cs
+++ b/src/TimeTracker.Api/Models/ChatMessage.cs
@@ -1,0 +1,3 @@
+namespace TimeTracker.Api.Models;
+
+public record ChatMessage(string Sender, string Text, DateTime Timestamp);

--- a/src/TimeTracker.Api/Models/ChatRequest.cs
+++ b/src/TimeTracker.Api/Models/ChatRequest.cs
@@ -1,0 +1,3 @@
+namespace TimeTracker.Api.Models;
+
+public record ChatRequest(string Text);

--- a/src/TimeTracker.Api/Models/ChatResponse.cs
+++ b/src/TimeTracker.Api/Models/ChatResponse.cs
@@ -1,0 +1,3 @@
+namespace TimeTracker.Api.Models;
+
+public record ChatResponse(string Text);

--- a/src/TimeTracker.Api/Program.cs
+++ b/src/TimeTracker.Api/Program.cs
@@ -1,12 +1,17 @@
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<TimeTracker.Agent.Services.IAgentService,
     TimeTracker.Agent.Services.AgentService>();
 builder.Services.AddSingleton<TimeTracker.Api.Services.IChatService,
     TimeTracker.Api.Services.ChatService>();
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.MapControllers();
 

--- a/src/TimeTracker.Api/Program.cs
+++ b/src/TimeTracker.Api/Program.cs
@@ -1,6 +1,10 @@
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddSingleton<TimeTracker.Agent.Services.IAgentService,
+    TimeTracker.Agent.Services.AgentService>();
+builder.Services.AddSingleton<TimeTracker.Api.Services.IChatService,
+    TimeTracker.Api.Services.ChatService>();
 
 var app = builder.Build();
 

--- a/src/TimeTracker.Api/Services/ChatService.cs
+++ b/src/TimeTracker.Api/Services/ChatService.cs
@@ -1,0 +1,33 @@
+using TimeTracker.Api.Models;
+using TimeTracker.Agent.Services;
+
+namespace TimeTracker.Api.Services;
+
+public interface IChatService
+{
+    ChatMessage Send(string userText);
+    IReadOnlyList<ChatMessage> GetHistory();
+}
+
+public class ChatService : IChatService
+{
+    private readonly IAgentService _agent;
+    private readonly List<ChatMessage> _messages = new();
+
+    public ChatService(IAgentService agent)
+    {
+        _agent = agent;
+    }
+
+    public IReadOnlyList<ChatMessage> GetHistory() => _messages.AsReadOnly();
+
+    public ChatMessage Send(string userText)
+    {
+        var userMessage = new ChatMessage("user", userText, DateTime.UtcNow);
+        _messages.Add(userMessage);
+        var responseText = _agent.Process(userText);
+        var agentMessage = new ChatMessage("agent", responseText, DateTime.UtcNow);
+        _messages.Add(agentMessage);
+        return agentMessage;
+    }
+}

--- a/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -1,2 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="..\TimeTracker.Agent\TimeTracker.Agent.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -2,4 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TimeTracker.Agent\TimeTracker.Agent.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- implement chat request/response models and service
- update controller with `messages` and `message` endpoints
- wire up services in `Program.cs`
- reference agent project

## Testing
- `dotnet build TimeTracker.sln` *(fails: command not found)*
- `npm --prefix src/TimeTracker.Client test`

------
https://chatgpt.com/codex/tasks/task_e_6855592afad4832b8e07c8133ff8a5e4